### PR TITLE
moved adventure button to the bottom of the page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -30,11 +30,11 @@
   <body>
     <a href="#/page/1" class="cover-link">
       <div class="cover">
-        <img src="img/cyoa.png" alt="Choose Your Own Adventure" class="cyoa">
         <h1>Open Source Templates</h1>
         <h2>The Curious Case of the Issue and Pull Request Template</h2>
         <div class="author">by Tal Ater</div>
         <img src="img/cover.jpg" alt="The Curious Case of the Issue and Pull Request Template" class="cover-image">
+        <img src="img/cyoa.png" alt="Choose Your Own Adventure" class="cyoa">
       </div>
     </a>
 


### PR DESCRIPTION
Am no ui/ux expert here but noticed that `choose your own adventure` is the call to action button which should come after the title and the cover image 🤔 

Changed this...
![screen shot 2018-03-08 at 11 57 28 pm](https://user-images.githubusercontent.com/2767425/37168988-9a1839da-232c-11e8-9bac-32b7c3a029e4.png)

to this...

![screen shot 2018-03-08 at 11 57 53 pm](https://user-images.githubusercontent.com/2767425/37169005-a935df44-232c-11e8-8d30-6f09b0bba863.png)

Would like to hear your thought! Thanks 😄 